### PR TITLE
WiX template produces per-user install MSI files, now (3.8 branch).

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
@@ -15,6 +15,9 @@
                 Comments="Windows Installer Package"
         />
 
+        <Property Id="ALLUSERS" Value="2" />
+        <Property Id="MSIINSTALLPERUSER" Value="1" />
+
         <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 
         <Icon Id="ProductIcon" SourceFile="{{ cookiecutter.app_name }}.ico" />


### PR DESCRIPTION
Notes:
- MSI files optionally installable per-machine, via CLI.
- No installer UI changes.

Context:
- https://github.com/beeware/briefcase/issues/382