### PR TITLE
Allow InstallScope to be determined by cookiecutter

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
@@ -13,10 +13,8 @@
                 InstallerVersion="200"
                 Compressed="yes"
                 Comments="Windows Installer Package"
+                InstallScope="{{ cookiecutter.install_scope or 'perUser' }}"
         />
-
-        <Property Id="ALLUSERS" Value="2" />
-        <Property Id="MSIINSTALLPERUSER" Value="1" />
 
         <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 


### PR DESCRIPTION
Allow the user to determine the install scope via cookiecutter.
This is a prep PR towards solving beeware/briefcase#498

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
