### PR TITLE
URI Schemes Support and create Desktop Icon

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,5 +10,7 @@
     "guid": "1409c8f5-c276-4cf3-a2fd-defcbdfef9a2",
     "install_scope": "perUser",
     "uri_schemes": "",
-    "_uri_schemes": "{% if cookiecutter.uri_schemes is iterable %}{{ cookiecutter.uri_schemes.join(',') }}{% else %}{{ cookiecutter.uri_schemes }}{% endif %}"
+    "_extensions": [
+        "briefcase.integrations.cookiecutter.ListExtension"
+    ]
 }

--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
@@ -92,8 +92,8 @@
                         WorkingDirectory="{{ cookiecutter.module_name }}_ROOTDIR"
                         Arguments="-m {{ cookiecutter.module_name }}" />
                     <RemoveFolder Id="DesktopFolder" On="uninstall"/>
-                    {%- if cookiecutter.uri_schemes -%}
-                        {%- for scheme in cookiecutter._uri_schemes.split(',') -%}
+                    {%- if cookiecutter.uri_schemes | parse_list -%}
+                        {%- for scheme in cookiecutter.uri_schemes | parse_list -%}
                         <RegistryKey 
                             Root="HKCU"
                             Key="Software\Classes\{{ scheme }}"


### PR DESCRIPTION
_Related to beeware/briefcase#624_
_As this PR contains a custom filter, don't merge this until the base PR has merged._

---

This PR also creates a desktop icon when the application has installed. I thought it can be useful for users as they need to search for the app on the system. Maybe it can be moved behind a configuration option later, or I can create separate PRs for creating desktop icon and URI schemes.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
