### PR TITLE
Add option for install scope to be user-selectable.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,5 @@
     "url": "http://example.com",
     "description": "Short description of app",
     "guid": "1409c8f5-c276-4cf3-a2fd-defcbdfef9a2",
-    "install_scope": "perUser"
+    "install_scope": ""
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,6 @@
     "url": "http://example.com",
     "description": "Short description of app",
     "guid": "1409c8f5-c276-4cf3-a2fd-defcbdfef9a2",
-    "install_scope": ""
+    "install_scope": "",
+    "_use_arch64": ""
 }

--- a/{{ cookiecutter.formal_name }}/unicode.wxl
+++ b/{{ cookiecutter.formal_name }}/unicode.wxl
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Codepage="utf-8" xmlns="http://schemas.microsoft.com/wix/2006/localization">
+    <String Id="InstallScopeDlgPerMachineDescription">[ProductName] will be installed in a per-machine folder and be available for all users. You must have local Administrator privileges.</String>
 </WixLocalization>

--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
@@ -54,7 +54,7 @@
         </Upgrade>
 
         <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFiles64Folder">
+            <Directory Id="{% if cookiecutter._use_arch64 %}ProgramFiles64Folder{% else %}ProgramFilesFolder{% endif %}">
                 <Directory Id="{{ cookiecutter.module_name }}_ROOTDIR" Name="{{ cookiecutter.formal_name }}" />
             </Directory>
 
@@ -63,7 +63,10 @@
                     <Component
                             Id="ApplicationShortcuts"
                             Guid="*"
-                            Win64="yes">
+                            {% if cookiecutter._use_arch64 -%}
+                            Win64="yes"
+                            {% endif -%}
+                    >
                         <Shortcut
                                 Id="ApplicationShortcut1"
                                 Name="{{ cookiecutter.formal_name }}"

--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.app_name }}.wxs
@@ -14,26 +14,27 @@
                 InstallerVersion="200"
                 Compressed="yes"
                 Comments="Windows Installer Package"
+                {% if cookiecutter.install_scope -%}
                 InstallScope="{{ cookiecutter.install_scope or 'perUser' }}"
+                {% endif -%}
         />
 
-        {%- if cookiecutter.install_scope == "perUser" -%}
-
+        {% if cookiecutter.install_scope == "perUser" -%}
         <Property Id="ALLUSERS" Value="2" />
         <Property Id="MSIINSTALLPERUSER" Value="1" />
+        {% endif -%}
 
-        {% endif %}
         <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 
         <Icon Id="ProductIcon" SourceFile="{{ cookiecutter.app_name }}.ico" />
 
         <Property Id="ARPPRODUCTICON" Value="ProductIcon" />
-        {%- if cookiecutter.url %}
+        {% if cookiecutter.url -%}
         <Property Id="ARPURLINFOABOUT" Value="{{ cookiecutter.url }}" />
-        {% endif %}
-        {%- if cookiecutter.author_email %}
+        {% endif -%}
+        {% if cookiecutter.author_email -%}
         <Property Id="ARPCONTACT" Value="{{ cookiecutter.author_email }}" />
-        {% endif %}
+        {% endif -%}
         <Property Id="ARPNOREPAIR" Value="1" />
         <Property Id="ARPNOMODIFY" Value="1" />
 
@@ -53,7 +54,7 @@
         </Upgrade>
 
         <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFilesFolder">
+            <Directory Id="ProgramFiles64Folder">
                 <Directory Id="{{ cookiecutter.module_name }}_ROOTDIR" Name="{{ cookiecutter.formal_name }}" />
             </Directory>
 
@@ -61,7 +62,8 @@
                 <Directory Id="ProgramMenuSubfolder" Name="{{ cookiecutter.formal_name }}">
                     <Component
                             Id="ApplicationShortcuts"
-                            Guid="*">
+                            Guid="*"
+                            Win64="yes">
                         <Shortcut
                                 Id="ApplicationShortcut1"
                                 Name="{{ cookiecutter.formal_name }}"
@@ -92,27 +94,45 @@
             <ComponentRef Id="ApplicationShortcuts"/>
         </Feature>
 
+        <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes" />
+        <WixVariable Id="WixUISupportPerMachine" Value="1" Overridable="yes" />
+
         <UI Id="UserInterface">
-          <Property Id="WIXUI_INSTALLDIR" Value="TARGETDIR" />
-          <Property Id="WixUI_Mode" Value="Custom" />
+        {% if not cookiecutter.install_scope -%}
+            <Property Id="WIXUI_INSTALLDIR" Value="tutorial_ROOTDIR" />
+            <Property Id="WixAppFolder" Value="WixPerUserFolder"/>
+        {% endif %}
+            <Property Id="WixUI_Mode" Value="Custom" />
 
-          <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
-          <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="9" Bold="yes" />
-          <TextStyle Id="WixUI_Font_Title"  FaceName="Tahoma" Size="9" Bold="yes" />
+            <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
+            <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="9" Bold="yes" />
+            <TextStyle Id="WixUI_Font_Title"  FaceName="Tahoma" Size="9" Bold="yes" />
 
-          <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+            <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
 
-          <DialogRef Id="ProgressDlg" />
-          <DialogRef Id="ErrorDlg" />
-          <DialogRef Id="FilesInUse" />
-          <DialogRef Id="FatalError" />
-          <DialogRef Id="UserExit" />
+            <DialogRef Id="ProgressDlg" />
+            <DialogRef Id="ErrorDlg" />
+            <DialogRef Id="FilesInUse" />
+            <DialogRef Id="FatalError" />
+            <DialogRef Id="UserExit" />
+        {% if cookiecutter.install_scope %}
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="EndDialog" Value="Return">1</Publish>
+        {% else %}
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallScopeDlg">1</Publish>
 
-          <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
-          <Publish Dialog="WelcomeDlg" Control="Next" Event="EndDialog" Value="Return" Order="2"></Publish>
+            <Publish Dialog="InstallScopeDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
+            <!-- If the user selected Per-User folder, ALLUSERS=2, MSIINSTALLPERUSER=1 -->
+            <Publish Dialog="InstallScopeDlg" Control="Next" Property="ALLUSERS" Value="2" Order="2">WixAppFolder = "WixPerUserFolder"</Publish>
+            <Publish Dialog="InstallScopeDlg" Control="Next" Property="MSIINSTALLPERUSER" Value="1" Order="3">WixAppFolder = "WixPerUserFolder"</Publish>
 
+            <!-- If the user selected Per-Machine folder, ALLUSERS=1, MSIINSTALLPERUSER="" -->
+            <Publish Dialog="InstallScopeDlg" Control="Next" Property="ALLUSERS" Value="1" Order="4">WixAppFolder = "WixPerMachineFolder"</Publish>
+            <Publish Dialog="InstallScopeDlg" Control="Next" Property="MSIINSTALLPERUSER" Value="{}" Order="5">WixAppFolder = "WixPerMachineFolder"</Publish>
+
+            <Publish Dialog="InstallScopeDlg" Control="Next" Event="EndDialog" Value="Return">1</Publish>
+        {% endif %}
+            <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
         </UI>
-
         <UIRef Id="WixUI_Common" />
     </Product>
 </Wix>


### PR DESCRIPTION
* If user scope is *not* explicitly provided, the user is presented with the option of a system vs user install.
* Modifies the install location to be `Program Files`, rather than `Program Files (x86)`, since we only support x64 on windows.

Refs:
* beeware/briefcase#688
* beeware/briefcase#382

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
